### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/src/build/muck/muck.psm1
+++ b/src/build/muck/muck.psm1
@@ -14,5 +14,5 @@ function ResolvePath() {
 Import-Module (ResolvePath "Unic.Bob.Rubble" "tools\Rubble")
 Import-Module (ResolvePath "Unic.Bob.Wendy" "tools\Wendy")
 
-Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.Tests.ps1 | Foreach-Object{ . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.Tests.ps1 | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that. 